### PR TITLE
Gitlab push rule

### DIFF
--- a/policies/apis/github-branch-protection.md
+++ b/policies/apis/github-branch-protection.md
@@ -140,6 +140,3 @@ attest:
 - **Description:** Allows fork syncing with the protected branch.
 - **Recommended Setting:** `false` - Limits potential unauthorized changes.
 
----
-
-These settings provide a framework for a secure and controlled development environment. Adjust them as necessary to fit the specific needs of your project and team.

--- a/policies/apis/github-branch-protection.rego
+++ b/policies/apis/github-branch-protection.rego
@@ -10,6 +10,7 @@ short_description = "Verify that built branch has branch protection rules set."
 description = "Branch protection rules prevent unplanned and unmanged changes to the branch. It is recommended to set branch protection rules for all branches."
 
 verify = v {
+    api_status_code == 200
 	v := {
 		"allow": allow,
 		"violation": {
@@ -22,6 +23,24 @@ verify = v {
 			"allow": allow,
 			"reason": reason,
 			"violations": count(violations),
+		}],
+	}
+}
+
+verify = v {
+    api_status_code != 200
+	v := {
+		"allow": false,
+		"violation": {
+			"type": "Branch Protection Violation",
+			"details": [{"api_status_code": api_status_code, "api_status": api_status}],
+		},
+		"short_description": short_description,
+		"description": description,
+		"summary": [{
+			"allow": false,
+			"reason": "api call failed",
+			"violations": [{"api_status_code": api_status_code, "api_status": api_status}],
 		}],
 	}
 }
@@ -109,7 +128,7 @@ get_result("required_signatures") = r {
 }
 
 check("required_signatures", expected) := r {
-    r:= {get_result("required_signatures") == expected}
+    r:= get_result("required_signatures") == expected
 }
 
 get_result("enforce_admins") := r {
@@ -118,7 +137,7 @@ get_result("enforce_admins") := r {
 }
 
 check("enforce_admins", expected) := r {
-    r:= {get_result("enforce_admins") == expected}
+    r:= get_result("enforce_admins") == expected
 }
 
 get_result("required_linear_history") := r {
@@ -127,7 +146,7 @@ get_result("required_linear_history") := r {
 }
 
 check("required_linear_history", expected) := r {
-    r:= {get_result("required_linear_history") == expected}
+    r:= get_result("required_linear_history") == expected
 }
 
 # Note: allow force pushes == true is the less secure option
@@ -137,7 +156,7 @@ get_result("allow_force_pushes") := r {
 }
 
 check("allow_force_pushes", expected) := r {
-    r:= {get_result("allow_force_pushes") == expected}
+    r:= get_result("allow_force_pushes") == expected
 }
 
 
@@ -148,7 +167,7 @@ get_result("allow_deletions") := r {
 }
 
 check("allow_deletions", expected) := r {
-    r:= {get_result("allow_deletions") == expected}
+    r:= get_result("allow_deletions") == expected
 }
 
 get_result("block_creations") := r {
@@ -157,7 +176,7 @@ get_result("block_creations") := r {
 }
 
 check("block_creations", expected) := r {
-    r:= {get_result("block_creations") == expected}
+    r:= get_result("block_creations") == expected
 }
 
 get_result("required_conversation_resolution") := r {
@@ -166,7 +185,7 @@ get_result("required_conversation_resolution") := r {
 }
 
 check("required_conversation_resolution", expected) := r {
-    r:= {get_result("required_conversation_resolution") == expected}
+    r:= get_result("required_conversation_resolution") == expected
 }
 
 get_result("lock_branch") := r {
@@ -175,7 +194,7 @@ get_result("lock_branch") := r {
 }
 
 check("lock_branch", expected) := r {
-    r:= {get_result("lock_branch") == expected}
+    r:= get_result("lock_branch") == expected
 }
 
 get_result("allow_fork_syncing") := r {
@@ -184,7 +203,7 @@ get_result("allow_fork_syncing") := r {
 }
 
 check("allow_fork_syncing", expected) := r {
-    r:= {get_result("allow_fork_syncing") == expected}
+    r:= get_result("allow_fork_syncing") == expected
 }
 
 # Require Pull Request Related Rules
@@ -195,7 +214,7 @@ get_result("required_pull_request_reviews.dismiss_stale_reviews") := r {
 }
 
 check("required_pull_request_reviews.dismiss_stale_reviews", expected) := r {
-    r:= {get_result("required_pull_request_reviews.dismiss_stale_reviews") == expected}
+    r:= get_result("required_pull_request_reviews.dismiss_stale_reviews") == expected
 }
 
 get_result("required_pull_request_reviews.required_approving_review_count") := r {
@@ -204,7 +223,7 @@ get_result("required_pull_request_reviews.required_approving_review_count") := r
 }
 
 check("required_pull_request_reviews.required_approving_review_count", expected) := r {
-    r:= {get_result("required_pull_request_reviews.required_approving_review_count") == expected}
+    r:= get_result("required_pull_request_reviews.required_approving_review_count") == expected
 }
 
 
@@ -214,7 +233,7 @@ get_result("required_pull_request_reviews.require_code_owner_reviews") := r {
 }
 
 check("required_pull_request_reviews.require_code_owner_reviews", expected) := r {
-    r:= {get_result("required_pull_request_reviews.require_code_owner_reviews") == expected}
+    r:= get_result("required_pull_request_reviews.require_code_owner_reviews") == expected
 }
 
 get_result("required_pull_request_reviews.require_last_push_approval") := r {
@@ -223,7 +242,7 @@ get_result("required_pull_request_reviews.require_last_push_approval") := r {
 }
 
 check("required_pull_request_reviews.require_last_push_approval", expected) := r {
-    r:= {get_result("required_pull_request_reviews.require_last_push_approval") == expected}
+    r:= get_result("required_pull_request_reviews.require_last_push_approval") == expected
 }
 
 
@@ -350,7 +369,7 @@ get_result("required_status_checks.strict") := r {
 }
 
 check("required_status_checks.strict", expected) := r {
-    r:= {get_result("required_status_checks.strict") == expected}
+    r:= get_result("required_status_checks.strict") == expected
 }
 
 
@@ -394,7 +413,10 @@ query := {
     "url": api_url,
     "timeout": "30s",
 }
-api_info := http.send(query).body
+response := http.send(query)
+api_status_code := response.status_code
+api_status := response.status
+api_info := response.body
 
 config := input.config.args.branch_protection_rules
 

--- a/policies/apis/gitlab-push-rules.md
+++ b/policies/apis/gitlab-push-rules.md
@@ -1,0 +1,70 @@
+# GitLab Push Rules Verification
+
+Valint policies can be used to verify settings via APIs. This document explains how to use Valint to verify GitHub branch protection settings.
+
+To verify run the following command:
+```bash
+valint verify -c policies/apis/gitlab-push-rules.yml --policy-args Project=12345678 --policy-args Token=$GL_TOKEN
+```
+
+Notes:
+- GL_TOKEN is a Gitlab access token. It should be crated with Maintainer role and api_read scope.
+- Although the policy does not consume any attestations, there should exist at least one attestation in the attestation store.
+
+
+
+This document outlines the GitLab push rule parameters for configuring repository push rules. Each parameter is described along with its type, requirement status, and a brief description. Recommendations for more secure settings are also provided.
+
+## Push Rule Parameters
+
+### `author_email_regex`
+- **Description:** All commit author emails must match this regex, e.g., `@my-company.com$`.
+- **Recommended Setting:** Use a regex pattern matching your organization's email domain to ensure commits are made by authorized personnel.
+
+### `branch_name_regex`
+- **Description:** All branch names must match this regex, e.g., `(feature|hotfix)/*`.
+- **Recommended Setting:** Enforce a naming convention for branches to aid in organization and consistency.
+
+### `commit_committer_check`
+- **Description:** Users can only push commits if the committer email is one of their own verified emails.
+- **Recommended Setting:** `true` - Ensures that the committer is a verified user, enhancing security.
+
+### `commit_committer_name_check`
+- **Description:** Users can only push commits if the commit author name is consistent with their GitLab account name.
+- **Recommended Setting:** `true` - Verifies the identity of the person making the commit.
+
+### `commit_message_negative_regex`
+- **Description:** No commit message is allowed to match this regex, e.g., `ssh://`.
+- **Recommended Setting:** Define a pattern to block commit messages containing specific undesired content or formats.
+
+### `commit_message_regex`
+- **Description:** All commit messages must match this regex, e.g., `Fixed \d+\..*`.
+- **Recommended Setting:** Use a regex pattern to enforce a specific format for commit messages, aiding clarity and tracking.
+
+### `deny_delete_tag`
+- **Description:** Deny deleting a tag.
+- **Recommended Setting:** `true` - Prevents accidental or unauthorized deletion of tags.
+
+### `file_name_regex`
+- **Description:** All committed file names must not match this regex, e.g., `(jar|exe)$`.
+- **Recommended Setting:** Set a pattern to restrict committing files of certain types or naming conventions, enhancing security.
+
+### `max_file_size`
+- **Description:** Maximum file size (MB) allowed for push.
+- **Recommended Setting:** Set a reasonable size limit to prevent overly large files from being committed.
+
+### `member_check`
+- **Description:** Restrict commits by author (email) to existing GitLab users.
+- **Recommended Setting:** `true` - Restricts commits to verified members, improving security.
+
+### `prevent_secrets`
+- **Description:** GitLab rejects any files that are likely to contain secrets.
+- **Recommended Setting:** `true` - Helps in preventing sensitive data exposure in the repository.
+
+### `reject_unsigned_commits`
+- **Description:** Rejects commits not signed through GPG.
+- **Recommended Setting:** `true` - Ensures authenticity and integrity of commits.
+
+---
+
+Adjust these settings as necessary to fit the specific needs of your project and team, balancing security with practicality.

--- a/policies/apis/gitlab-push-rules.rego
+++ b/policies/apis/gitlab-push-rules.rego
@@ -1,0 +1,235 @@
+package verify
+
+import future.keywords.in
+import future.keywords.every
+
+default allow := false
+
+short_description = "Verify that the project has push rules set."
+
+description = "Push rules prevent unplanned and unmanged changes to the project repository. It is recommended to set push rules for all projects."
+
+verify = v {
+    api_status_code == 200
+	v := {
+		"allow": allow,
+		"violation": {
+			"type": "Push Rules",
+			"details": violations,
+		},
+		"short_description": short_description,
+		"description": description,
+		"summary": [{
+			"allow": allow,
+			"reason": reason,
+			"violations": count(violations),
+		}],
+	}
+}
+
+verify = v {
+    api_status_code != 200
+	v := {
+		"allow": false,
+		"violation": {
+			"type": "Push Rules Setting Violation",
+			"details": [{"api_status_code": api_status_code, "api_status": api_status}],
+		},
+		"short_description": short_description,
+		"description": description,
+		"summary": [{
+			"allow": false,
+			"reason": "api call failed",
+			"violations": [{"api_status_code": api_status_code, "api_status": api_status, "api_raw_response": api_info}],
+		}],
+	}
+}
+
+
+reason = v {
+	allow
+	v := "all required push rules are in place."
+}
+
+reason = v {
+	not allow
+	v := "found push rules missing."
+}
+
+allow {
+	count(violations) == 0
+}
+
+
+violations = j {
+    api_info == null
+    j:= [{ "push rules set": false }]
+}
+
+
+violations = j {
+    api_info != null
+	j := {r |
+		some rule,expected in input.config.args.push_rule
+        not check(rule, expected)
+		r = {
+			"push rule": rule,
+            "expected": expected,
+            "found": get_result(rule),
+			"result": check(rule, expected)
+		}
+	}
+}
+
+evaluations = j {
+    not field_exists("message", api_info)
+	j := {r |
+		some rule,expected in input.config.args.push_rule
+        #not check(rule, expected)
+		r = {
+			"push rule": rule,
+            "expected": expected,
+            "found": get_result(rule),
+			"result": check(rule, expected)
+		}
+	}
+}
+
+
+get_result("commit_message_regex") := r {
+    t := object.get(api_info, ["commit_message_regex"], "")
+    r:= t
+}
+
+check("commit_message_regex", expected) := r {
+    r:= str_norm(get_result("commit_message_regex")) == str_norm(expected)
+}
+
+get_result("commit_message_negative_regex") := r {
+    t := object.get(api_info, ["commit_message_negative_regex"], null)
+    r:= t
+}
+
+check("commit_message_negative_regex", expected) := r {
+    r:= str_norm(get_result("commit_message_negative_regex")) == str_norm(expected)
+}
+
+get_result("branch_name_regex") := r {
+    t := object.get(api_info, ["branch_name_regex"], null)
+    r:= t
+}
+
+check("branch_name_regex", expected) := r {
+    r:= str_norm(get_result("branch_name_regex")) == str_norm(expected)
+}
+
+get_result("deny_delete_tag") := r {
+    t := object.get(api_info, ["deny_delete_tag"], false)
+    r:= t
+}
+
+check("deny_delete_tag", expected) := r {
+    r:= get_result("deny_delete_tag") == expected
+}
+
+get_result("member_check") := r {
+    t := object.get(api_info, ["member_check"], false)
+    r:= t
+}
+
+check("member_check", expected) := r {
+    r:= get_result("member_check") == expected
+}
+
+get_result("prevent_secrets") := r {
+    t := object.get(api_info, ["prevent_secrets"], false)
+    r:= t
+}
+
+check("prevent_secrets", expected) := r {
+    r:= get_result("prevent_secrets") == expected
+}
+
+get_result("author_email_regex") := r {
+    t := object.get(api_info, ["author_email_regex"], null)
+    r:= t
+}
+
+check("author_email_regex", expected) := r {
+    r:= str_norm(get_result("author_email_regex")) == str_norm(expected)
+}
+
+get_result("file_name_regex") := r {
+    t := object.get(api_info, ["file_name_regex"], null)
+    r:= t
+}
+
+check("file_name_regex", expected) := r {
+    r:= str_norm(get_result("file_name_regex")) == str_norm(expected)
+}
+
+get_result("max_file_size") := r {
+    t := object.get(api_info, ["max_file_size"], 0)
+    r:= t
+}
+
+check("max_file_size", expected) := r {
+    r:= get_result("max_file_size") == expected
+}
+
+get_result("commit_committer_check") := r {
+    t := object.get(api_info, ["commit_committer_check"], null)
+    r:= t
+}
+
+check("commit_committer_check", expected) := r {
+    r:= get_result("commit_committer_check") == expected
+}
+
+get_result("reject_unsigned_commits") := r {
+    t := object.get(api_info, ["reject_unsigned_commits"], null)
+    r:= t
+}
+
+check("reject_unsigned_commits", expected) := r {
+    r:= bool_norm(get_result("reject_unsigned_commits")) == bool_norm(expected)
+}
+
+str_norm(null) := r {
+    r := ""
+}
+
+str_norm(s) := r {
+    s != null
+    r := s
+}
+
+bool_norm(null) := r {
+    r := false
+}
+
+bool_norm(s) := r {
+    s != null
+    r := s
+}
+
+api_url := sprintf("https://gitlab.com/api/v4/projects/%v/push_rule", [input.config.args.project])
+query := {
+    "method": "GET",
+    "headers": { 
+            "Private-Token": input.config.args.api_token
+    },
+    "url": api_url,
+    "timeout": "30s",
+}
+response := http.send(query)
+api_status_code := response.status_code
+api_status := response.status
+api_info := response.body
+
+
+config := input.config.args.push_rule
+
+field_exists(field, obj)  {
+    _ = obj[field]
+}

--- a/policies/apis/gitlab-push-rules.yml
+++ b/policies/apis/gitlab-push-rules.yml
@@ -11,8 +11,8 @@ attest:
           signed: false
           rego:
             args:
-              api_token: glpat-iZGayztywxBYbafzkMh2
-              project: "43544122"
+              api_token: '{{ .Args.Token }}'
+              project: '{{ .Args.Project }}'
               push_rule:
                 commit_message_regex: ""
                 commit_message_negative_regex: null

--- a/policies/apis/gitlab-push-rules.yml
+++ b/policies/apis/gitlab-push-rules.yml
@@ -1,0 +1,28 @@
+attest:
+  cocosign:
+    policies:
+    - name: gitlab-push-rules
+      enable: true
+      modules:
+      - name: gitlab-push-rules
+        type: verify-artifact
+        enable: true
+        input:
+          signed: false
+          rego:
+            args:
+              api_token: glpat-iZGayztywxBYbafzkMh2
+              project: "43544122"
+              push_rule:
+                commit_message_regex: ""
+                commit_message_negative_regex: null
+                branch_name_regex: null
+                deny_delete_tag: false
+                member_check: false
+                prevent_secrets: false
+                author_email_regex: ""
+                file_name_regex: "abc"
+                max_file_size: 100
+                commit_committer_name_check: null
+                reject_unsigned_commits: null
+            path: gitlab-push-rules.rego

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,8 @@ Each implemented policy in the table that has an example in this repo has a link
 | No License Modification | Prevent license modifications. | src and dst [SBOM](#sboms) |
 | Verify Source code Integrity | Verify that the artifact source code has not been modified | src and dst [Git SBOM](#git) |
 | Verify Dependencies Integrity | Verify that specific files or folders have not been modified | src and dst [SBOM](#sboms) |
-| [Verify Github Branch Protection](github-branch-protection-explained.md) | Verify that the branch protection rules are compliant to required | None |
+| [Verify Github Branch Protection](policies/apis/github-branch-protection.md) | Verify that the branch protection rules are compliant to required | None |
+| [Verify GitLab Push Rules](policies/apis/gitlab-push-rules.md) | Verify that the push rules are compliant to required. GitLabs push rules overlap some of GitHub's branch protection rules | None |
 ### General Information
 
 Most of the policies in this repo consist of two files: a `.yaml` and a `.rego`.


### PR DESCRIPTION
Added GitLab push rules policy + updates for both github and gitlab:

support non 200 OK messages in the verify object for easying debugging.
bug fix
support for gitlab for strange cases (using null\true instead of false\true, or null for an uninitialized string field).
 (moved the pr to scribe-security and not scribe public)